### PR TITLE
Skeleton combatloop with options

### DIFF
--- a/Heal.hs
+++ b/Heal.hs
@@ -1,0 +1,16 @@
+module Heal where
+
+-- A healing item has a name and the amount of health it restores
+data Heal = Heal { healName :: String, healAmount :: Int }
+
+-- Define Healing item constants
+potion = Heal "Potion" 20
+superPotion = Heal "Super Potion" 50
+
+getHealName :: Heal -> String
+getHealName = healName
+
+getHealAmount :: Heal -> Int
+getHealAmount = healAmount
+
+

--- a/Heal.hs
+++ b/Heal.hs
@@ -1,4 +1,13 @@
-module Heal where
+module Heal 
+(
+    Heal,
+    nullHeal,
+    allHeals,
+    allHealNames,
+    getHealByName,
+    getHealName,
+    getHealAmount,
+) where
 
 -- A healing item has a name and the amount of health it restores
 data Heal = Heal { healName :: String, healAmount :: Int }
@@ -7,10 +16,30 @@ data Heal = Heal { healName :: String, healAmount :: Int }
 potion = Heal "Potion" 20
 superPotion = Heal "Super Potion" 50
 
+-- Constant Null Heal, used to cancel item usage
+nullHeal = Heal "NULL" 0
+
+-- Healing item "catalogue"
+allHeals = [potion, superPotion]
+
+-- Helper function for allHealNames
+addHealName :: [String] -> Heal -> [String]
+addHealName [] h = [healName h]
+addHealName lst h = lst ++ [healName h]
+
+-- Provide all Heal names available for use
+allHealNames :: [String]
+allHealNames = foldl addHealName [] allHeals
+
+-- Retrieve the details for a Heal by its name
+getHealByName :: String -> [Heal] -> Heal
+getHealByName s lst
+    | s == healName (head lst) = head lst
+    | otherwise = getHealByName s (tail lst)
+
+-- Getters for Heal records
 getHealName :: Heal -> String
 getHealName = healName
 
 getHealAmount :: Heal -> Int
 getHealAmount = healAmount
-
-

--- a/Moves.hs
+++ b/Moves.hs
@@ -1,0 +1,24 @@
+module Moves 
+(
+    Move(Move),
+    getMoveName,
+    getMoveDamage,
+    nullMove,
+) where
+
+-- The amount of damage a particular move inflicts
+type Power = Int
+
+-- Constructor for a Move, it has a name and an amount of damage
+data Move = Move { moveName :: String, damage :: Power }
+            deriving (Show)
+
+-- Constant Null Move, used for cancelling decision to use a Move
+nullMove = Move "NULL" 0
+
+-- "Public" getters
+getMoveName :: Move -> String
+getMoveName = moveName
+
+getMoveDamage :: Move -> Power
+getMoveDamage = damage

--- a/Moves.hs
+++ b/Moves.hs
@@ -11,7 +11,6 @@ type Power = Int
 
 -- Constructor for a Move, it has a name and an amount of damage
 data Move = Move { moveName :: String, damage :: Power }
-            deriving (Show)
 
 -- Constant Null Move, used for cancelling decision to use a Move
 nullMove = Move "NULL" 0

--- a/Pokemon.hs
+++ b/Pokemon.hs
@@ -12,6 +12,7 @@ module Pokemon
     getMoveByName,
     getMoves,
     useMoveOn,
+    useHealOn,
 ) where
 
 import Heal
@@ -22,7 +23,6 @@ data Pokemon = Pokemon1 { name :: String, health :: Int, move1 :: Move }
              | Pokemon2 { name :: String, health :: Int, move1 :: Move, move2 :: Move }
              | Pokemon3 { name :: String, health :: Int, move1 :: Move, move2 :: Move, move3 :: Move } 
              | Pokemon4 { name :: String, health :: Int, move1 :: Move, move2 :: Move, move3 :: Move, move4 :: Move }
-             deriving (Show)
 
 -- Define Pokemon constants
 bulbasaur = Pokemon2 "Bulbasaur" 90 (Move "Tackle" 20) (Move "Vine Whip" 20)
@@ -73,3 +73,11 @@ useMoveOn m (Pokemon1 n h m1) = Pokemon1 n (h - getMoveDamage m) m1
 useMoveOn m (Pokemon2 n h m1 m2) = Pokemon2 n (h - getMoveDamage m) m1 m2
 useMoveOn m (Pokemon3 n h m1 m2 m3) = Pokemon3 n (h - getMoveDamage m) m1 m2 m3
 useMoveOn m (Pokemon4 n h m1 m2 m3 m4) = Pokemon4 n (h - getMoveDamage m) m1 m2 m3 m4
+
+-- Simulate a Pokemon taking the effects of a Heal
+-- TODO: limit to a max health
+useHealOn :: Heal -> Pokemon -> Pokemon
+useHealOn i (Pokemon1 n h m1) = Pokemon1 n (h + getHealAmount i) m1
+useHealOn i (Pokemon2 n h m1 m2) = Pokemon2 n (h + getHealAmount i) m1 m2
+useHealOn i (Pokemon3 n h m1 m2 m3) = Pokemon3 n (h + getHealAmount i) m1 m2 m3
+useHealOn i (Pokemon4 n h m1 m2 m3 m4) = Pokemon4 n (h + getHealAmount i) m1 m2 m3 m4

--- a/Pokemon.hs
+++ b/Pokemon.hs
@@ -5,21 +5,39 @@ module Pokemon
     allPokemon,
     allPokemonNames,
     getPokemonByName,
+    getName,
     getHealth,
+    getMoveName,
+    getMoveDamage,
+    nullMove,
+    getMoveByName,
     getMoves,
+    useMoveOn,
 ) where
 
 -- The amount of damage a particular move inflicts
 type Power = Int
 
 -- Constructor for a Move, it has a name and an amount of damage
-data Move = Move String Power
+data Move = Move { moveName :: String, damage :: Power }
+            deriving (Show)
+
+-- "Public" getters
+getMoveName :: Move -> String
+getMoveName = moveName
+
+getMoveDamage :: Move -> Power
+getMoveDamage = damage
+
+-- Constant Null Move, used for cancelling decision to use a Move
+nullMove = Move "NULL" 0
 
 -- A Pokemon has a name, health remaining, and up to 4 moves
-data Pokemon = Pokemon4 { name :: String, maxHealth :: Int, move1 :: Move, move2 :: Move, move3 :: Move, move4 :: Move }
-             | Pokemon3 { name :: String, maxHealth :: Int, move1 :: Move, move2 :: Move, move3 :: Move }
-             | Pokemon2 { name :: String, maxHealth :: Int, move1 :: Move, move2 :: Move }
-             | Pokemon1 { name :: String, maxHealth :: Int, move1 :: Move }
+data Pokemon = Pokemon1 { name :: String, health :: Int, move1 :: Move }            
+             | Pokemon2 { name :: String, health :: Int, move1 :: Move, move2 :: Move }
+             | Pokemon3 { name :: String, health :: Int, move1 :: Move, move2 :: Move, move3 :: Move } 
+             | Pokemon4 { name :: String, health :: Int, move1 :: Move, move2 :: Move, move3 :: Move, move4 :: Move }
+             deriving (Show)
 
 -- Define Pokemon constants
 bulbasaur = Pokemon2 "Bulbasaur" 90 (Move "Tackle" 20) (Move "Vine Whip" 20)
@@ -46,9 +64,16 @@ getPokemonByName s lst
     | s == name (head lst) = head lst
     | otherwise = getPokemonByName s (tail lst)
 
--- Simple "public" getter function
+-- Simple "public" getter functions
+getName :: Pokemon -> String
+getName = name
+
 getHealth :: Pokemon -> Int
-getHealth = maxHealth
+getHealth = health
+
+getMoveByName :: String -> Pokemon -> Move
+-- TODO: which move to use
+getMoveByName s = move1
 
 -- Getter function: determine the moves available on this Pokemon
 getMoves :: Pokemon -> [String]
@@ -56,3 +81,10 @@ getMoves (Pokemon1 _ _ (Move n1 _)) = [n1]
 getMoves (Pokemon2 _ _ (Move n1 _) (Move n2 _)) = [n1, n2]
 getMoves (Pokemon3 _ _ (Move n1 _) (Move n2 _) (Move n3 _)) = [n1, n2, n3]
 getMoves (Pokemon4 _ _ (Move n1 _) (Move n2 _) (Move n3 _) (Move n4 _)) = [n1, n2, n3, n4]
+
+-- Simulate a Pokemon taking the effects of a Move
+useMoveOn :: Move -> Pokemon -> Pokemon
+useMoveOn m (Pokemon1 n h m1) = Pokemon1 n (h - getMoveDamage m) m1
+useMoveOn m (Pokemon2 n h m1 m2) = Pokemon2 n (h - getMoveDamage m) m1 m2
+useMoveOn m (Pokemon3 n h m1 m2 m3) = Pokemon3 n (h - getMoveDamage m) m1 m2 m3
+useMoveOn m (Pokemon4 n h m1 m2 m3 m4) = Pokemon4 n (h - getMoveDamage m) m1 m2 m3 m4

--- a/Pokemon.hs
+++ b/Pokemon.hs
@@ -8,29 +8,14 @@ module Pokemon
     getName,
     getHealth,
     getMoveName,
-    getMoveDamage,
     nullMove,
     getMoveByName,
     getMoves,
     useMoveOn,
 ) where
 
--- The amount of damage a particular move inflicts
-type Power = Int
-
--- Constructor for a Move, it has a name and an amount of damage
-data Move = Move { moveName :: String, damage :: Power }
-            deriving (Show)
-
--- "Public" getters
-getMoveName :: Move -> String
-getMoveName = moveName
-
-getMoveDamage :: Move -> Power
-getMoveDamage = damage
-
--- Constant Null Move, used for cancelling decision to use a Move
-nullMove = Move "NULL" 0
+import Heal
+import Moves
 
 -- A Pokemon has a name, health remaining, and up to 4 moves
 data Pokemon = Pokemon1 { name :: String, health :: Int, move1 :: Move }            

--- a/main.hs
+++ b/main.hs
@@ -7,20 +7,10 @@ import System.IO
 import Text.Read 
 
 import Pokemon
-
--- A healing item has a name and the amount of health it restores
-data Heal = Heal String Int
-
--- On each turn, either we perform a move or use a healing item
-type BattleAction = Move
-type HealthAction = Heal
+import Heal
 
 -- State of the battle
 type BattleState = (Pokemon, Pokemon)
-
--- Define Healing item constants
-potion = Heal "Potion" 20
-superPotion = Heal "Super Potion" 50
 
 -- Main function to start game
 play :: IO ()
@@ -105,7 +95,6 @@ personBattle bs =
                                             else
                                                 do
                                                     putStrLn (getName (fst bs) ++ " used " ++ getMoveName move ++ "!")
-                                                    -- TODO: update battlestate
                                                     computerBattle (fst bs, useMoveOn move (snd bs))
                             -- else if action == "Item"
                             --     then

--- a/main.hs
+++ b/main.hs
@@ -23,7 +23,7 @@ potion = Heal "Potion" 20
 superPotion = Heal "Super Potion" 50
 
 -- Main function to start game
-play :: IO () -- TODO: update type
+play :: IO ()
 play = 
     do
         putStrLn "--------------------------------------"
@@ -33,9 +33,13 @@ play =
         choice <- getLine 
         case (readMaybe choice :: Maybe String) of
             Nothing -> putStrLn "We hope to see you again!"
-            -- TODO: list Pokemon names when "list"
             Just choice ->
-                if choice `elem` allPokemonNames
+                if choice == "list"
+                    then
+                        do
+                            print allPokemonNames
+                            play
+                else if choice `elem` allPokemonNames
                     then
                         do
                             putStrLn "The Battle Begins!"
@@ -47,23 +51,24 @@ play =
                             putStrLn "Not an available Pokemon name. Try again."
                             play
 
+-- Helper function to ensure whether the state of the game is continuing or will complete
 checkBattleState :: BattleState -> IO Bool
 checkBattleState bs =
     let maxHealth1 = getHealth (fst bs)
         maxHealth2 = getHealth (snd bs)
     in
     do
-        if (maxHealth1 == 0) && (maxHealth2 == 0)
+        if (maxHealth1 <= 0) && (maxHealth2 <= 0)
             then
                 do
                     putStrLn "It's a draw!"
                     return True
-        else if maxHealth1 == 0
+        else if maxHealth1 <= 0
             then
                 do
                     putStrLn "You lost!"
                     return True
-        else if maxHealth2 == 0
+        else if maxHealth2 <= 0
             then
                 do
                     putStrLn "You won!"
@@ -71,9 +76,7 @@ checkBattleState bs =
         else
             return False
 
-
-
-
+-- Player's turn to perform an action
 personBattle :: BattleState -> IO ()
 personBattle bs =
     do
@@ -83,9 +86,56 @@ personBattle bs =
                 putStrLn "The battle has ended."
             else
                 -- TODO: poll actions from player
-                putStrLn "hello world"
+                do
+                    putStrLn "--------------------------------"
+                    putStrLn ("Your " ++ getName (fst bs) ++ " has " ++ show (getHealth (fst bs)) ++ " health.")
+                    putStrLn ("Your opponent's " ++ getName (snd bs) ++ " has " ++ show (getHealth (snd bs)) ++ " health.")
+                    putStrLn "[\"Move\"] Use a Pokemon move / [\"Item\"] Use an item"
+                    action <- getLine
+                    case (readMaybe action :: Maybe String) of
+                        Nothing -> personBattle bs
+                        Just action ->
+                            if action == "Move"
+                                then
+                                    do
+                                        move <- pollMove (fst bs)
+                                        if getMoveName move == "NULL"
+                                            then 
+                                                personBattle bs
+                                            else
+                                                do
+                                                    putStrLn (getName (fst bs) ++ " used " ++ getMoveName move ++ "!")
+                                                    -- TODO: update battlestate
+                                                    computerBattle (fst bs, useMoveOn move (snd bs))
+                            -- else if action == "Item"
+                            --     then
+                            --         pollItem
+                            else
+                                personBattle bs
 
+-- Continuously ask for a move
+-- TODO: if possible, allow for people to change their mind i.e. go back to Move or Item
+pollMove :: Pokemon -> IO Move
+pollMove p = 
+    do
+        let moves = getMoves p
+        putStrLn ("Which move should " ++ getName p ++ " use? (leave empty to cancel)")
+        print moves
+        moveChoice <- getLine
+        case (readMaybe moveChoice :: Maybe String) of
+            Nothing -> return nullMove
+            Just moveChoice ->
+                if moveChoice `elem` moves
+                    then
+                        -- TODO: actual move not just default
+                        return (getMoveByName moveChoice p)
+                    else
+                        pollMove p
 
+-- pollItem :: IO ()
+-- pollItem = return
+
+-- Computer's turn, less involved action from user necessary
 computerBattle :: BattleState -> IO ()
 computerBattle bs =
     do
@@ -94,8 +144,7 @@ computerBattle bs =
             then
                 putStrLn "The battle has ended."
             else
-                -- TODO: poll actions from computer
-                putStrLn "hello world"
-
-
-                    
+                do
+                    -- TODO: poll actions from computer
+                    putStrLn ("The opponent's " ++ getName (snd bs) ++ " used NULL")
+                    personBattle bs


### PR DESCRIPTION
Still left to implement for MVP:

- Limit health restoration to a max health value (maybe taken from Pokemon base catalogue)
- Move selection for Player 1
- Add computer decision-making for its turn

Stretch goals:
- Randomize computer Pokemon choice
- Add type advantages for more flexibility of choice rather than just max damage move
- General meta balancing